### PR TITLE
Job priority and background processing

### DIFF
--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -473,8 +473,8 @@ Gearman.prototype.registerWorker = function(name, func){
     this.workers[name] = func;
 };
 
-Gearman.prototype.submitJob = function(name, payload, uniq){
-    return new this.Job(this, name, payload, uniq);
+Gearman.prototype.submitJob = function(name, payload, uniq, options){
+    return new this.Job(this, name, payload, uniq, (typeof options != "object" ? {} : options));
 };
 
 // WORKER
@@ -519,8 +519,7 @@ Gearman.prototype.Worker.prototype.error = function(error){
 };
 
 // JOB
-
-Gearman.prototype.Job = function(gearman, name, payload, uniq){
+Gearman.prototype.Job = function(gearman, name, payload, uniq, options){
     Stream.call(this);
 
     this.gearman = gearman;
@@ -529,7 +528,18 @@ Gearman.prototype.Job = function(gearman, name, payload, uniq){
 
     this.timeoutTimer = null;
 
-    gearman.sendCommand("SUBMIT_JOB", name, uniq ? uniq : false, payload, this.receiveHandle.bind(this));
+    var jobType = "SUBMIT_JOB";
+    if (typeof options == "object") {
+        if (typeof options.priority == "string" &&
+            ['high', 'low'].indexOf(options.priority) != -1) {
+            jobType += "_" + options.priority.toUpperCase();
+        }
+    
+        if (typeof options.background == "boolean" && options.background)
+            jobType += "_BG";
+    }
+
+   gearman.sendCommand(jobType, name, uniq ? uniq : false, payload, !options.background ? this.receiveHandle.bind(this) : false);
 };
 utillib.inherits(Gearman.prototype.Job, Stream);
 


### PR DESCRIPTION
Adds options to submitJob for priority (high, low, default: none), and background. Examples:

``` javascript
// High Priority
var options = {priority: "high"};
gearman.submitJob("task", data, uniq, options);

// Low Priority, Background
var options = {priority: "low", background: true};
gearman.submitJob("task", data, uniq, options);
```
