### PR TITLE
Replace recursive process.nextTick usage with setImmediate 

### DIFF
--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -4,6 +4,10 @@ var netlib = require("net"),
 
 module.exports = Gearman;
 
+if (typeof setImmediate == 'undefined') {
+    var setImmediate = process.nextTick;
+}
+
 function Gearman(host, port, debug){
     Stream.call(this);
 


### PR DESCRIPTION
As per http://blog.nodejs.org/2013/03/11/node-v0-10-0-stable/

You've got a recursive process.nextTick happening in gearman.js - and we're seeing this crash node occasionally with:

```
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 (node) warning: Recursive process.nextTick detected. This will break in the next version of node. Please use setImmediate for recursive deferral.
 RangeError: Maximum call stack size exceeded
```

More info here:
http://blog.peakji.com/node-js-process-nexttick-and-setimmediate/

BTW it would be great to see these changes pushed to npm!
