### PR TITLE
Add a response size limit for jobs

### DIFF
--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -408,6 +408,7 @@ Gearman.prototype.receive = function(chunk){
     }
 
     if (this.limit && commandName === "WORK_COMPLETE" && bodyLength && (bodyLength > this.limit)) {
+        args.push(bodyLength);
         this.error_JOB_REPSONSE_TOO_BIG.apply(this, args, bodyLength);
     }
     // Run command
@@ -461,12 +462,14 @@ Gearman.prototype.receive_WORK_FAIL = function(handle){
 };
 
 Gearman.prototype.error_JOB_REPSONSE_TOO_BIG = function(handle){
-    var job = this.currentJobs[handle];
+    var job = this.currentJobs[handle], error;
     if(job){
         delete this.currentJobs[handle];
         if(!job.aborted){
             job.abort();
-            job.emit("error", new Error("Job response too big"));
+            error = new Error("Job response too big")
+            error.size = handle[2];
+            job.emit("error", error);
         }
     }
 };

--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -461,14 +461,14 @@ Gearman.prototype.receive_WORK_FAIL = function(handle){
     }
 };
 
-Gearman.prototype.error_JOB_REPSONSE_TOO_BIG = function(handle){
+Gearman.prototype.error_JOB_REPSONSE_TOO_BIG = function(handle, paload, size){
     var job = this.currentJobs[handle], error;
     if(job){
         delete this.currentJobs[handle];
         if(!job.aborted){
             job.abort();
             error = new Error("Job response too big")
-            error.size = handle[2];
+            error.size = size;
             job.emit("error", error);
         }
     }

--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -8,12 +8,13 @@ if (typeof setImmediate == 'undefined') {
     var setImmediate = process.nextTick;
 }
 
-function Gearman(host, port, debug){
+function Gearman(host, port, debug, limit){
     Stream.call(this);
 
     this.debug = !!debug;
     this.port = port || 4730;
     this.host = host || "localhost";
+    this.limit = limit && (limit+12) || 0;
 
     this.init();
 }
@@ -301,7 +302,17 @@ Gearman.prototype.receive = function(chunk){
     if(!data.length){
         return;
     }
-    
+
+    if (this.skip>0) {
+
+        if (chunk.length<this.skip) {
+            this.skip -= chunk.length;
+            return;
+        }
+        chunk = chunk.slice(this.skip);
+        this.skip = 0;     
+    }
+
     // if theres a remainder value, tie it together with the incoming chunk
     if(this.remainder){
         this.remainder.copy(data, 0, 0);
@@ -326,9 +337,17 @@ Gearman.prototype.receive = function(chunk){
 
     // response needs to be 12 bytes + payload length
     bodyLength = data.readUInt32BE(8);
+
+
+    //if the response is bigger than the limit, skip
+    if (this.limit && bodyLength>this.limit) {
+        this.skip = bodyLength + 12 - data.length;
+    }
+
     if(data.length < 12 + bodyLength){
         this.remainder = data;
-        return;
+        
+        if (!this.skip) { return; }
     }
 
     // keep the remainder if incoming data is larger than needed
@@ -388,8 +407,11 @@ Gearman.prototype.receive = function(chunk){
         });
     }
 
+    if (this.limit && commandName === "WORK_COMPLETE" && bodyLength && (bodyLength > this.limit)) {
+        this.error_JOB_REPSONSE_TOO_BIG.apply(this, args, bodyLength);
+    }
     // Run command
-    if(typeof this["receive_" + commandName] == "function"){
+    else if(typeof this["receive_" + commandName] == "function"){
         if(commandName == "JOB_CREATED" && this.handleCallbackQueue.length){
             args = args.concat(this.handleCallbackQueue.shift());
         }
@@ -434,6 +456,17 @@ Gearman.prototype.receive_WORK_FAIL = function(handle){
         if(!job.aborted){
             job.abort();
             job.emit("error", new Error("Job failed"));
+        }
+    }
+};
+
+Gearman.prototype.error_JOB_REPSONSE_TOO_BIG = function(handle){
+    var job = this.currentJobs[handle];
+    if(job){
+        delete this.currentJobs[handle];
+        if(!job.aborted){
+            job.abort();
+            job.emit("error", new Error("Job response too big"));
         }
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -173,7 +173,7 @@ exports["max response size"] = {
     },
 
     "Worker fails": function(test){
-        test.expect(1);
+        test.expect(2);
         
         this.gearman.registerWorker("test", function(payload, worker){
             worker.end(new Array(200000).join("x"));
@@ -183,6 +183,7 @@ exports["max response size"] = {
 
         job.on("error", function(err){
             test.ok(err,"Job response too big");
+            test.ok(err.size);
             this.gearman.on("idle", function(){
                 test.done();
             });

--- a/test/test.js
+++ b/test/test.js
@@ -129,9 +129,132 @@ exports["Worker and Client"] = {
 
 };
 
-exports["Job timeout"] = {
+exports["max response size"] = {
+
     setUp: function(callback){
 
+        this.gearman = new Gearman("localhost", 4730, false, 10000);
+        this.gearman.on("connect", function(){
+            callback();
+        });
+        this.gearman.on("error", function(e){
+            console.log('gearman.error:', e.message);
+        });
+        this.gearman.connect();
+    },
+
+    tearDown: function(callback){
+        this.gearman.on("close", function(){
+            callback();
+        });
+        this.gearman.close();
+    },
+    
+    "Send/Receive data": function(test){
+        test.expect(2);
+        var data1 = new Buffer([0,1,2,3,4,5,6,7,8,9,10]),
+            data2 = new Buffer([245,246,247,248,249,250,251,252,253,254,255]);
+        
+        this.gearman.registerWorker("test", function(payload, worker){
+            test.equal(payload.toString("base64"), data1.toString("base64"));
+            worker.end(data2);
+        });
+
+        var job = this.gearman.submitJob("test", data1);
+        job.on("data", function(payload){
+            test.equal(payload.toString("base64"), data2.toString("base64"));
+        });
+
+        job.on("end", function(){
+            this.gearman.on("idle", function(){
+                test.done();
+            });
+        });
+    },
+
+    "Worker fails": function(test){
+        test.expect(1);
+        
+        this.gearman.registerWorker("test", function(payload, worker){
+            worker.end(new Array(200000).join("x"));
+        });
+
+        var job = this.gearman.submitJob("test", "test");
+
+        job.on("error", function(err){
+            test.ok(err,"Job response too big");
+            this.gearman.on("idle", function(){
+                test.done();
+            });
+        });
+
+        job.on("end", function(err){
+            test.ok(false, "Job did not fail");
+            test.done();
+        });
+    },
+
+
+    "2 Workers": function(test){
+        test.expect(3);
+        
+        this.gearman.registerWorker("test", function(payload, worker){
+            worker.end(new Array(200000).join("x"));
+        });
+
+        this.gearman.registerWorker("echo", function(payload, worker){
+            worker.end(payload);
+        });
+
+        var job2 = this.gearman.submitJob("echo", "hello world");
+        job2.on("data", function(payload){
+            test.equal(payload.toString(), "hello world");
+        });
+
+        var job1 = this.gearman.submitJob("test", "test");
+        job1.on("error", function(err){
+            test.ok(err,"Job response too big");
+            this.gearman.on("idle", function(){
+                test.done();
+            });
+        });
+
+        var job3 = this.gearman.submitJob("echo", "hello");
+        job3.on("data", function(payload){
+            test.equal(payload.toString(), "hello");
+        });
+
+
+    },
+
+    "Send/Receive data": function(test){
+        test.expect(2);
+        var data1 = new Buffer([0,1,2,3,4,5,6,7,8,9,10]),
+            data2 = new Buffer([245,246,247,248,249,250,251,252,253,254,255]);
+        
+        this.gearman.registerWorker("test", function(payload, worker){
+            test.equal(payload.toString("base64"), data1.toString("base64"));
+            worker.end(data2);
+        });
+
+        var job = this.gearman.submitJob("test", data1);
+        job.on("data", function(payload){
+            test.equal(payload.toString("base64"), data2.toString("base64"));
+        });
+
+        job.on("end", function(){
+            this.gearman.on("idle", function(){
+                test.done();
+            });
+        });
+    },
+};
+
+exports["Job timeout"] = {
+
+
+    setUp: function(callback){
+        var self = this;
         this.gearman = new Gearman("localhost");
         this.gearman.on("connect", function(){
             callback();
@@ -140,17 +263,18 @@ exports["Job timeout"] = {
             console.log(e.message);
         });
         this.gearman.connect();
-        
         this.gearman.registerWorker("test", function(payload, worker){
             setTimeout(function(){
                 worker.end("OK");
-            }, 300);
+            }, 200);
         });
     },
 
     tearDown: function(callback){
         this.gearman.on("close", function(){
-            callback();
+            setTimeout(function(){
+                callback();
+            }, 400);
         });
         this.gearman.close();
     },
@@ -202,19 +326,26 @@ exports["Job timeout"] = {
         
         var job = this.gearman.submitJob("test", "test");
         job.setTimeout(400, function(){
-            test.ok(false,"Timeout occured");
-            test.done();
+            test.ok(false, "Timeout occured");
+            this.gearman.on('idle', function() {
+                test.done();
+            });
         });
 
         job.on("error", function(err){
-            test.ok(false,"Job failed");
-            test.done();
+            test.ok(false, "Job failed");
+            this.gearman.on('idle', function() {
+                test.done();
+            });
         });
 
-        job.on("end", function(err){
+        job.on("end", function(){
             test.ok(true, "Job completed before timeout");
-            test.done();
+            this.gearman.on('idle', function() {
+                test.done();
+            });
         });
+
     }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -183,7 +183,7 @@ exports["max response size"] = {
 
         job.on("error", function(err){
             test.ok(err,"Job response too big");
-            test.ok(err.size);
+            test.equal(err.size, 200020);
             this.gearman.on("idle", function(){
                 test.done();
             });


### PR DESCRIPTION
This pull requests adds a limit parameter that restricts the maximum response size of a job. 
If a response is bigger than the limit, a "response too big error" is returned, the error will have a size property that includes the responseSize.

Unit tests were added for this too.
