### PR TITLE
Adds warning support

### DIFF
--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -124,7 +124,7 @@ Gearman.paramCount = {
 };
 
 Gearman.prototype.connect = function(){
-    
+
     if(this.connected || this.connecting){
         // juhul kui ühendus on juba olemas käivita protsessimine
         if(this.connected && !this.processing){
@@ -132,7 +132,7 @@ Gearman.prototype.connect = function(){
         }
         return false;
     }
-    
+
     this.connecting = true;
 
     if(this.debug){
@@ -140,13 +140,13 @@ Gearman.prototype.connect = function(){
     }
 
     this.socket = (netlib.connect || netlib.createConnection)(this.port, this.host);
-        
+
     this.socket.on("connect", (function(){
         this.socket.setKeepAlive(true);
-            
+
         this.connecting = false;
         this.connected = true;
-    
+
         if(this.debug){
             console.log("connected!");
         }
@@ -156,7 +156,7 @@ Gearman.prototype.connect = function(){
 
     }).bind(this));
 
-     
+
 
     this.socket.on("end", this.close.bind(this));
     this.socket.on("close", this.close.bind(this));
@@ -203,7 +203,7 @@ Gearman.prototype.closeConnection = function(){
                 delete this.currentWorkers[i];
             }
         }
-        
+
         this.init();
     }
 };
@@ -238,7 +238,7 @@ Gearman.prototype.sendCommandToServer = function(){
         args = Array.prototype.slice.call(arguments),
         commandName, commandId, commandCallback,
         i, len, bodyLength = 0, curpos = 12;
-    
+
     if(!this.connected){
         this.commandQueue.unshift(args);
         return this.connect();
@@ -301,7 +301,7 @@ Gearman.prototype.receive = function(chunk){
     if(!data.length){
         return;
     }
-    
+
     // if theres a remainder value, tie it together with the incoming chunk
     if(this.remainder){
         this.remainder.copy(data, 0, 0);
@@ -311,7 +311,7 @@ Gearman.prototype.receive = function(chunk){
     }else{
         data = chunk;
     }
-    
+
     // response header needs to be at least 12 bytes
     // otherwise keep the current chunk as remainder
     if(data.length<12){
@@ -402,6 +402,21 @@ Gearman.prototype.receive = function(chunk){
     }
 };
 
+Gearman.prototype.receive_WORK_WARNING = function(handle, err) {
+    var job;
+    try {
+        err = JSON.parse(err);
+    } catch(e) {
+        
+    }
+    if((job = this.currentJobs[handle])){
+        if (job.aborted) {
+            return;
+        }
+        job.emit("warning", err);
+    }
+};
+
 Gearman.prototype.receive_NO_JOB = function(){
     this.sendCommand("PRE_SLEEP");
     this.emit("idle");
@@ -451,12 +466,12 @@ Gearman.prototype.receive_WORK_COMPLETE = function(handle, payload){
         delete this.currentJobs[handle];
         if(!job.aborted){
             clearTimeout(job.timeoutTimer);
-            
+
             if(payload){
                 job.emit("data", payload);
             }
-            
-            job.emit("end");    
+
+            job.emit("end");
         }
     }
 };
@@ -502,6 +517,28 @@ Gearman.prototype.Worker.prototype.write = function(data){
     this.gearman.sendCommand("WORK_DATA", this.handle, data);
 };
 
+Gearman.prototype.Worker.prototype.warn = function(err) {
+    if (this.finished) {
+        return;
+    }
+    // this.gearman.sendCommand("WORK_WARNING", this.handle, err.toString());
+    var errObj;
+    if (err instanceof Error) {
+        errObj = {
+            'message': err.message,
+            'stack': err.stack
+        };
+    } else if (typeof err === 'object') {
+        errObj = err;
+    } else {
+        errObj = {
+            'message': err ? err.toString() : null
+        };
+    }
+    var errJSON = JSON.stringify(errObj);
+    this.gearman.sendCommand("WORK_WARNING", this.handle, errJSON);
+};
+
 Gearman.prototype.Worker.prototype.end = function(data){
     if(this.finished){
         return;
@@ -538,7 +575,7 @@ Gearman.prototype.Job = function(gearman, name, payload, uniq, options){
             ['high', 'low'].indexOf(options.priority) != -1) {
             jobType += "_" + options.priority.toUpperCase();
         }
-    
+
         if (typeof options.background == "boolean" && options.background)
             jobType += "_BG";
     }


### PR DESCRIPTION
This PR adds support for passing warning messages from a worker via `worker.warn(warning)`. The client can listen for these messages via `client.on('warning', (warning) => { ... });`.
