### PR TITLE
Removes unnecessary 5th argument of the background job

### DIFF
--- a/lib/gearman.js
+++ b/lib/gearman.js
@@ -543,7 +543,12 @@ Gearman.prototype.Job = function(gearman, name, payload, uniq, options){
             jobType += "_BG";
     }
 
-   gearman.sendCommand(jobType, name, uniq ? uniq : false, payload, !options.background ? this.receiveHandle.bind(this) : false);
+    var args = [jobType, name, uniq || false, payload];
+    if (!options.background) {
+        args.push(this.receiveHandle.bind(this));
+    }
+
+    gearman.sendCommand.apply(gearman, args);
 };
 utillib.inherits(Gearman.prototype.Job, Stream);
 


### PR DESCRIPTION
It's done to avoid the null terminator (NUL) in the end of payload. 

Without this fix, node-gearman sends the one additional argument 
```
Sending: SUBMIT_JOB_BG with 4 params
 -  <Buffer 00 52 45 51 00 00 00 12 00 00 01 96 6c 6f 79 61 6c 74 79 2d 66 65 65 64 73 00 00 7b 22 73 69 64 22 3a 22 31 31 32 22 2c 22 75 72 6c 22 3a 22 68 74 74 ... >
  - ARG:0  test
  - ARG:1  
  - ARG:2  {"foo":"bar"}
  - ARG:3  
```

The 4th argument is converted to the null terminator by gearman server and concatenated with payload. It is not obvious and causes an error "SyntaxError: Unexpected token" when trying to parse JSON

With this fix, debug output returns:

```
Sending: SUBMIT_JOB_BG with 3 params
 -  <Buffer 00 52 45 51 00 00 00 12 00 00 01 95 6c 6f 79 61 6c 74 79 2d 66 65 65 64 73 00 00 7b 22 73 69 64 22 3a 22 31 31 32 22 2c 22 75 72 6c 22 3a 22 68 74 74 ... >
  - ARG:0  test
  - ARG:1  
  - ARG:2  {"foo":"bar"}
```